### PR TITLE
Close #32: Finish definition of plugin interface

### DIFF
--- a/library/Ginger/Environment/Plugin.php
+++ b/library/Ginger/Environment/Plugin.php
@@ -32,5 +32,35 @@ interface Plugin
      * @return void
      */
     public function registerOn(Environment $workflowEnv);
+
+    /**
+     * Return a composer cli require package argument string
+     * for the package that includes the supported Ginger\Types of the plugin
+     *
+     * This can be same package as of the plugin itself but be aware that this package will be installed on every node
+     *
+     * @example: vendor/package:2.*
+     *
+     * @return string
+     */
+    public function getSupportedTypesComposerPackage();
+
+    /**
+     * Return an array containing each supported Ginger\Type class as key
+     * and all supported workflow messages for that Ginger\Type as value list
+     *
+     * You can use the short hand of the workflow messages:
+     * - collect-data   -> tells the system that the type can be collected by the plugin
+     * - data-collected -> tells the system that the plugin wants to be informed when the type was collected
+     * - process-data   -> tells the system that the type can be processed by the plugin
+     * - data-processed -> tells the system that the plugin wants to be informed when the type was processed
+     *
+     * @example
+     *
+     * ['Vendor\Type\User' => ['collect-data', 'data-processed'], 'Vendor\Type\']
+     *
+     * @return array
+     */
+    public function getSupportedMessagesByTypeMap();
 }
  

--- a/tests/GingerTest/Mock/SimpleEnvPlugin.php
+++ b/tests/GingerTest/Mock/SimpleEnvPlugin.php
@@ -55,5 +55,21 @@ class SimpleEnvPlugin implements Plugin
     {
         return $this->registered;
     }
+
+    /**
+     * @return string
+     */
+    public function getSupportedTypesComposerPackage()
+    {
+        return "";
+    }
+
+    /**
+     * @return array
+     */
+    public function getSupportedMessagesByTypeMap()
+    {
+        return [];
+    }
 }
  


### PR DESCRIPTION
- A Plugin should have name
- A Plugin should register on the environment
- A Plugin should provide the composer package
  that includes the supported Ginger\Type classes
- A Plugin should provide a Type => WorkflowMessage map
