### PR TITLE
Rename LinearMessagingProcess to LinearProcess

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -18,7 +18,7 @@ system in the comments of the script.
 `Ginger\Console` provides an easy way to start a pre configured workflow from the command line. The example
 ships with such a workflow configuration. Please see [example2-workflow.config.php](config/example2-workflow.config.php).
 
-To run the example (currently only possible on a *nix system) navigate to
+To run the example navigate to
 `<ginger-package-root>/examples` and fire up
 `./bin/ginger collect GingerExample\\Type\\SourceUser --config-file config/example2-workflow.config.php --verbose`
 

--- a/library/Ginger/Processor/LinearProcess.php
+++ b/library/Ginger/Processor/LinearProcess.php
@@ -25,7 +25,7 @@ use Ginger\Processor\Task\Task;
  * @package Ginger\Processor
  * @author Alexander Miertsch <kontakt@codeliner.ws>
  */
-class LinearMessagingProcess extends Process
+class LinearProcess extends Process
 {
     /**
      * Start or continue the process with the help of given WorkflowEngine and optionally with given WorkflowMessage

--- a/tests/GingerTest/Processor/LinearProcessTest.php
+++ b/tests/GingerTest/Processor/LinearProcessTest.php
@@ -14,7 +14,7 @@ namespace GingerTest\Processor;
 
 use Ginger\Message\MessageNameUtils;
 use Ginger\Message\WorkflowMessage;
-use Ginger\Processor\LinearMessagingProcess;
+use Ginger\Processor\LinearProcess;
 use Ginger\Processor\NodeName;
 use Ginger\Processor\ProcessId;
 use Ginger\Processor\Task\CollectData;
@@ -33,7 +33,7 @@ use Prooph\ServiceBus\Router\EventRouter;
  * @package GingerTest\Processor
  * @author Alexander Miertsch <kontakt@codeliner.ws>
  */
-class LinearMessagingProcessTest extends TestCase
+class LinearProcessTest extends TestCase
 {
     /**
      * @test
@@ -42,7 +42,7 @@ class LinearMessagingProcessTest extends TestCase
     {
         $task = CollectData::from('test-case', UserDictionary::prototype());
 
-        $process = LinearMessagingProcess::setUp(NodeName::defaultName(), [$task]);
+        $process = LinearProcess::setUp(NodeName::defaultName(), [$task]);
 
         $process->perform($this->workflowEngine);
 
@@ -71,7 +71,7 @@ class LinearMessagingProcessTest extends TestCase
     {
         $task = CollectData::from('test-case', UserDictionary::prototype());
 
-        $process = LinearMessagingProcess::setUp(NodeName::defaultName(), [$task]);
+        $process = LinearProcess::setUp(NodeName::defaultName(), [$task]);
 
         $wfm = WorkflowMessage::collectDataOf(UserDictionary::prototype());
 
@@ -114,7 +114,7 @@ class LinearMessagingProcessTest extends TestCase
     {
         $task = CollectData::from('test-case', UserDictionary::prototype());
 
-        $process = LinearMessagingProcess::setUp(NodeName::defaultName(), [$task]);
+        $process = LinearProcess::setUp(NodeName::defaultName(), [$task]);
 
         //We deactivate the router so message cannot be dispatched
         $this->workflowEngine->getCommandBusFor('test-case')->deactivate($this->commandRouter);
@@ -135,7 +135,7 @@ class LinearMessagingProcessTest extends TestCase
 
         $task2 = ProcessData::address('test-target', ['GingerTest\Mock\UserDictionary']);
 
-        $process = LinearMessagingProcess::setUp(NodeName::defaultName(), [$task1, $task2]);
+        $process = LinearProcess::setUp(NodeName::defaultName(), [$task1, $task2]);
 
         $wfm = WorkflowMessage::collectDataOf(UserDictionary::prototype());
 
@@ -204,7 +204,7 @@ class LinearMessagingProcessTest extends TestCase
     {
         $task = ProcessData::address('test-target', ['GingerTest\Mock\TargetUserDictionary']);
 
-        $process = LinearMessagingProcess::setUp(NodeName::defaultName(), [$task]);
+        $process = LinearProcess::setUp(NodeName::defaultName(), [$task]);
 
         $wfm = WorkflowMessage::collectDataOf(UserDictionary::prototype());
 


### PR DESCRIPTION
- All processes work with messages so we can remove this information from
  the name
